### PR TITLE
GPS 속도 표시 및 속도에 따른 색상 변경

### DIFF
--- a/AccidentHere/AppDelegate.swift
+++ b/AccidentHere/AppDelegate.swift
@@ -13,6 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        Thread.sleep(forTimeInterval: 1.0)
         // Override point for customization after application launch.
         return true
     }

--- a/AccidentHere/Base.lproj/Main.storyboard
+++ b/AccidentHere/Base.lproj/Main.storyboard
@@ -28,8 +28,8 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Czt-3x-GBy">
                                 <rect key="frame" x="95" y="314.66666666666669" width="200" height="215.00000000000006"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="50" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8C7-ys-yCG">
-                                        <rect key="frame" x="0.0" y="0.0" width="200" height="191"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8C7-ys-yCG">
+                                        <rect key="frame" x="0.0" y="0.0" width="102.33333333333333" height="191"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="160"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -52,6 +52,10 @@
                             <constraint firstItem="8qC-la-a7X" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="yO6-00-iYE"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="speedLabel" destination="8C7-ys-yCG" id="F1A-7E-qPb"/>
+                        <outlet property="statusLabel" destination="6tb-xv-fCD" id="gWp-Qm-mde"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/AccidentHere/ViewController.swift
+++ b/AccidentHere/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate{
             if (speed > baseline) {
                 self.view.backgroundColor = UIColor.red
             } else {
-                self.view.backgroundColor = nil
+                self.view.backgroundColor = UIColor(named: "backgroundColor")
             }
             
             speedLabel.text = (String(format: "%.0f", speed))

--- a/AccidentHere/ViewController.swift
+++ b/AccidentHere/ViewController.swift
@@ -5,12 +5,57 @@
 //  Created by 이소민 on 2021/11/23.
 //
 import UIKit
+import CoreLocation
 
-class ViewController: UIViewController{
+class ViewController: UIViewController, CLLocationManagerDelegate{
+    
+    var locationManager: CLLocationManager = CLLocationManager()
 
+    var baseline = 10.0
+
+    @IBOutlet var speedLabel: UILabel!
+    @IBOutlet var statusLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // Ask for Authorisation from the User.
+        self.locationManager.requestAlwaysAuthorization()
+
+        // For use in foreground
+        self.locationManager.requestWhenInUseAuthorization()
+
+        if CLLocationManager.locationServicesEnabled() {
+            locationManager.delegate = self
+            // 10미터 이내 정확도
+            //locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+            locationManager.desiredAccuracy = kCLLocationAccuracyBest
+            locationManager.startUpdatingLocation()
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        let location = locations.last
+        if (location!.horizontalAccuracy > 0) {
+            updateLocationInfo(latitude: location!.coordinate.latitude, longitude: location!.coordinate.longitude, speed: location!.speed)
+        }
+    }
+
+    func updateLocationInfo(latitude: CLLocationDegrees, longitude: CLLocationDegrees, speed: CLLocationSpeed) {
+        let speed = (speed * 3.6)
+        
+        // Checking if speed is less than zero
+        if (speed > 0) {
+            if (speed > baseline) {
+                self.view.backgroundColor = UIColor.red
+            } else {
+                self.view.backgroundColor = nil
+            }
+            
+            speedLabel.text = (String(format: "%.0f", speed))
+        } else {
+            speedLabel.text = "0"
+        }
     }
 }
 


### PR DESCRIPTION
- GPS 속도 표시
- `baseline` 이상의 속도 시 배경 색상 `UIColor.red`로 설정
- application launch 할 때 delay 추가

## 생각해 볼 점
- GPS를 받아 올 수 없을 때 대응
    - 예로 GPS를 받아올 수 없다는 아이콘 표시 (네이버 지도) ...
- 초기 `statusLabel` 값
- 충돌 감지 모드로 진입하는 방법
- 충돌 감지 모드가 아닐 때에도 속도 측정을 할 것인지
- `CLLocationManager()`를 통해 더 받아야 할 값이 있는지
    - 사고 위치를 추적하기 위해서 latitude, longitude 값은 받아와야겠군